### PR TITLE
feat(report): Aggregate transactions by category in distribution summary

### DIFF
--- a/financial_management/src/main/java/com/example/financial_management/controllers/ReportController.java
+++ b/financial_management/src/main/java/com/example/financial_management/controllers/ReportController.java
@@ -20,6 +20,7 @@ import com.example.financial_management.model.report.response.AccountSummary;
 import com.example.financial_management.model.report.response.CategoryReportResponse;
 import com.example.financial_management.model.report.response.CompareReportResponse;
 import com.example.financial_management.model.report.response.DailyReportResponse;
+import com.example.financial_management.model.report.response.DistributionSummary;
 import com.example.financial_management.model.report.response.MonthlyReportResponse;
 import com.example.financial_management.model.report.response.SummaryReportResponse;
 import com.example.financial_management.model.transaction.TransactionResponse;
@@ -55,6 +56,14 @@ public class ReportController {
             @Parameter(hidden = true) @AuthenticationPrincipal Auth auth) {
         return new AbstractResponse<AccountSummary>()
                 .withData(() -> reportService.getReportByAccount(accountId, auth));
+    }
+
+    @GetMapping("/distribution/{accountId}")
+    public ResponseEntity<AbstractResponse<DistributionSummary>> getReportDistributionByAccount(
+            @PathVariable UUID accountId,
+            @Parameter(hidden = true) @AuthenticationPrincipal Auth auth) {
+        return new AbstractResponse<DistributionSummary>()
+                .withData(() -> reportService.getReportDistributionByAccount(accountId, auth));
     }
 
     @PostMapping("/summary")

--- a/financial_management/src/main/java/com/example/financial_management/model/report/response/CategoryDistribution.java
+++ b/financial_management/src/main/java/com/example/financial_management/model/report/response/CategoryDistribution.java
@@ -1,0 +1,23 @@
+package com.example.financial_management.model.report.response;
+
+import com.example.financial_management.constant.Category;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryDistribution {
+    private int category;
+    private BigDecimal total;
+    private String categoryName;
+
+    public CategoryDistribution(int category, BigDecimal total) {
+        this.category = category;
+        this.total = total;
+        this.categoryName = Category.getName(category);
+    }
+}

--- a/financial_management/src/main/java/com/example/financial_management/model/report/response/DistributionSummary.java
+++ b/financial_management/src/main/java/com/example/financial_management/model/report/response/DistributionSummary.java
@@ -1,0 +1,20 @@
+package com.example.financial_management.model.report.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DistributionSummary {
+    private BigDecimal startBalance;
+    private BigDecimal endBalance;
+    private BigDecimal totalIncome;
+    private BigDecimal totalExpense;
+    private List<CategoryDistribution> incomeByCategory;
+    private List<CategoryDistribution> expenseByCategory;
+}

--- a/financial_management/src/main/java/com/example/financial_management/repository/TransactionRepository.java
+++ b/financial_management/src/main/java/com/example/financial_management/repository/TransactionRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.example.financial_management.model.report.response.CategoryDistribution;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,122 +19,139 @@ import com.example.financial_management.model.report.response.CategoryReportItem
 import com.example.financial_management.model.report.response.MonthlyReportResponseItem;
 
 public interface TransactionRepository extends JpaRepository<Transaction, UUID>, JpaSpecificationExecutor<Transaction> {
-    Page<Transaction> findByUserIdOrderByCreatedAtDesc(UUID userId, Pageable pageable);
+        Page<Transaction> findByUserIdOrderByCreatedAtDesc(UUID userId, Pageable pageable);
 
-    Optional<Transaction> findByIdAndUserId(UUID id, UUID userId);
+        Optional<Transaction> findByIdAndUserId(UUID id, UUID userId);
 
-    List<Transaction> findAllByUserIdAndType(UUID userId, int type);
+        List<Transaction> findAllByUserIdAndType(UUID userId, int type);
 
-    List<Transaction> findAllByAccountId(UUID accountId);
+        List<Transaction> findAllByAccountId(UUID accountId);
 
-    List<Transaction> findAllByUserIdAndCategory(UUID userId, int category);
+        List<Transaction> findAllByUserIdAndCategory(UUID userId, int category);
 
-    List<Transaction> findAllByUserIdAndCurrency(UUID userId, int currency);
+        List<Transaction> findAllByUserIdAndCurrency(UUID userId, int currency);
 
-    List<Transaction> findAllByUserIdAndCreatedAtBetween(
-            UUID userId,
-            LocalDateTime from,
-            LocalDateTime to);
+        List<Transaction> findAllByUserIdAndCreatedAtBetween(
+                        UUID userId,
+                        LocalDateTime from,
+                        LocalDateTime to);
 
-    boolean existsByAccountIdAndCurrencyNot(UUID accountId, int currency);
+        boolean existsByAccountIdAndCurrencyNot(UUID accountId, int currency);
 
-    Page<Transaction> findByAccountIdAndUserId(UUID accountId, UUID userId, Pageable pageable);
+        Page<Transaction> findByAccountIdAndUserId(UUID accountId, UUID userId, Pageable pageable);
 
-    List<Transaction> findAllByAccountIdAndUserId(UUID accountId, UUID userId);
+        List<Transaction> findAllByAccountIdAndUserId(UUID accountId, UUID userId);
 
-    @Query("""
-                SELECT COALESCE(SUM(t.amount), 0)
-                FROM Transaction t
-                WHERE t.userId = :userId
-                  AND (:accountId IS NULL OR t.accountId = :accountId)
-                  AND (:type IS NULL OR t.type = :type)
-            """)
-    Optional<BigDecimal> sumAmountByType(@Param("userId") UUID userId,
-            @Param("accountId") UUID accountId,
-            @Param("type") Integer type);
+        List<Transaction> findAllByAccountIdAndUserIdAndType(UUID accountId, UUID userId, int type);
 
-    @Query("""
-                SELECT COALESCE(SUM(t.amount), 0)
-                FROM Transaction t
-                WHERE t.userId = :userId
-                  AND t.createdAt BETWEEN :from AND :to
-                  AND (:accountId IS NULL OR t.accountId = :accountId)
-                  AND (:type IS NULL OR t.type = :type)
-            """)
-    Optional<BigDecimal> sumAmount(@Param("userId") UUID userId,
-            @Param("from") LocalDateTime from,
-            @Param("to") LocalDateTime to,
-            @Param("accountId") UUID accountId,
-            @Param("type") Integer type);
+        @Query("""
+                            SELECT COALESCE(SUM(t.amount), 0)
+                            FROM Transaction t
+                            WHERE t.userId = :userId
+                              AND (:accountId IS NULL OR t.accountId = :accountId)
+                              AND (:type IS NULL OR t.type = :type)
+                        """)
+        Optional<BigDecimal> sumAmountByType(@Param("userId") UUID userId,
+                        @Param("accountId") UUID accountId,
+                        @Param("type") Integer type);
 
-    @Query(value = """
-                  SELECT
-                CAST([created_at] AS date) AS date,
-                account_id,
-                COALESCE(SUM(CASE WHEN [type] = 1 THEN [amount] ELSE 0 END), 0) AS income,
-                COALESCE(SUM(CASE WHEN [type] = 0 THEN [amount] ELSE 0 END), 0) AS expense
-            FROM [transactions]
-            WHERE [user_id] = :userId
-              AND [created_at] BETWEEN :start AND :end
-              AND (:accountId IS NULL OR [account_id] = :accountId)
-            GROUP BY CAST([created_at] AS date), account_id
-            ORDER BY CAST([created_at] AS date), account_id
-                  """, nativeQuery = true)
-    List<Object[]> sumDaily(
-            @Param("userId") UUID userId,
-            @Param("start") LocalDateTime start,
-            @Param("end") LocalDateTime end,
-            @Param("accountId") UUID accountId);
-
-    @Query("""
-                SELECT new com.example.financial_management.model.report.response.MonthlyReportResponseItem(
-                    MONTH(t.createdAt),
-                    COALESCE(SUM(CASE WHEN t.type = 1 THEN t.amount ELSE 0 END), 0),
-                    COALESCE(SUM(CASE WHEN t.type = 0 THEN t.amount ELSE 0 END), 0),
-                    YEAR(t.createdAt)
-                )
-                FROM Transaction t
-                WHERE t.userId = :userId
-                  AND YEAR(t.createdAt) = :year
-                  AND (:accountId IS NULL OR t.accountId = :accountId)
-                GROUP BY MONTH(t.createdAt), YEAR(t.createdAt)
-                ORDER BY MONTH(t.createdAt)
-            """)
-    List<MonthlyReportResponseItem> sumMonthly(
-            @Param("userId") UUID userId,
-            @Param("year") int year,
-            @Param("accountId") UUID accountId);
-
-    @Query("""
-                SELECT new com.example.financial_management.model.report.response.CategoryReportItem(
-                    t.category,
-                    COALESCE(SUM(CASE WHEN t.type = 0 THEN t.amount ELSE 0 END), 0),
-                    COALESCE(SUM(CASE WHEN t.type = 1 THEN t.amount ELSE 0 END), 0)
-                )
-                FROM Transaction t
-                WHERE t.userId = :userId
-                  AND (:accountId IS NULL OR t.accountId = :accountId)
-                  AND (:fromDate IS NULL OR t.createdAt >= :fromDate)
-                  AND (:toDate IS NULL OR t.createdAt <= :toDate)
-                GROUP BY t.category
-            """)
-    List<CategoryReportItem> sumByCategory(
-            @Param("userId") UUID userId,
-            @Param("accountId") UUID accountId,
-            @Param("fromDate") LocalDateTime fromDate,
-            @Param("toDate") LocalDateTime toDate);
-
-    @Query("""
-            SELECT SUM(t.amount)
+        @Query("""
+            SELECT new com.example.financial_management.model.report.response.CategoryDistribution(
+                t.category,
+                SUM(t.amount)
+            )
             FROM Transaction t
             WHERE t.userId = :userId
-            AND t.category = :categoryId
-            AND MONTH(t.createdAt) = :month
-            AND YEAR(t.createdAt) = :year
+              AND t.accountId = :accountId
+              AND t.type = :type
+            GROUP BY t.category
             """)
-    BigDecimal sumSpendingByCategoryAndMonth(
-            UUID userId,
-            int categoryId,
-            int month,
-            int year);
+        List<CategoryDistribution> sumAmountByCategoryAndType(@Param("userId") UUID userId,
+                                                              @Param("accountId") UUID accountId,
+                                                              @Param("type") int type);
+
+        @Query("""
+                            SELECT COALESCE(SUM(t.amount), 0)
+                            FROM Transaction t
+                            WHERE t.userId = :userId
+                              AND t.createdAt BETWEEN :from AND :to
+                              AND (:accountId IS NULL OR t.accountId = :accountId)
+                              AND (:type IS NULL OR t.type = :type)
+                        """)
+        Optional<BigDecimal> sumAmount(@Param("userId") UUID userId,
+                        @Param("from") LocalDateTime from,
+                        @Param("to") LocalDateTime to,
+                        @Param("accountId") UUID accountId,
+                        @Param("type") Integer type);
+
+        @Query(value = """
+                              SELECT
+                            CAST([created_at] AS date) AS date,
+                            account_id,
+                            COALESCE(SUM(CASE WHEN [type] = 1 THEN [amount] ELSE 0 END), 0) AS income,
+                            COALESCE(SUM(CASE WHEN [type] = 0 THEN [amount] ELSE 0 END), 0) AS expense
+                        FROM [transactions]
+                        WHERE [user_id] = :userId
+                          AND [created_at] BETWEEN :start AND :end
+                          AND (:accountId IS NULL OR [account_id] = :accountId)
+                        GROUP BY CAST([created_at] AS date), account_id
+                        ORDER BY CAST([created_at] AS date), account_id
+                              """, nativeQuery = true)
+        List<Object[]> sumDaily(
+                        @Param("userId") UUID userId,
+                        @Param("start") LocalDateTime start,
+                        @Param("end") LocalDateTime end,
+                        @Param("accountId") UUID accountId);
+
+        @Query("""
+                            SELECT new com.example.financial_management.model.report.response.MonthlyReportResponseItem(
+                                MONTH(t.createdAt),
+                                COALESCE(SUM(CASE WHEN t.type = 1 THEN t.amount ELSE 0 END), 0),
+                                COALESCE(SUM(CASE WHEN t.type = 0 THEN t.amount ELSE 0 END), 0),
+                                YEAR(t.createdAt)
+                            )
+                            FROM Transaction t
+                            WHERE t.userId = :userId
+                              AND YEAR(t.createdAt) = :year
+                              AND (:accountId IS NULL OR t.accountId = :accountId)
+                            GROUP BY MONTH(t.createdAt), YEAR(t.createdAt)
+                            ORDER BY MONTH(t.createdAt)
+                        """)
+        List<MonthlyReportResponseItem> sumMonthly(
+                        @Param("userId") UUID userId,
+                        @Param("year") int year,
+                        @Param("accountId") UUID accountId);
+
+        @Query("""
+                            SELECT new com.example.financial_management.model.report.response.CategoryReportItem(
+                                t.category,
+                                COALESCE(SUM(CASE WHEN t.type = 0 THEN t.amount ELSE 0 END), 0),
+                                COALESCE(SUM(CASE WHEN t.type = 1 THEN t.amount ELSE 0 END), 0)
+                            )
+                            FROM Transaction t
+                            WHERE t.userId = :userId
+                              AND (:accountId IS NULL OR t.accountId = :accountId)
+                              AND (:fromDate IS NULL OR t.createdAt >= :fromDate)
+                              AND (:toDate IS NULL OR t.createdAt <= :toDate)
+                            GROUP BY t.category
+                        """)
+        List<CategoryReportItem> sumByCategory(
+                        @Param("userId") UUID userId,
+                        @Param("accountId") UUID accountId,
+                        @Param("fromDate") LocalDateTime fromDate,
+                        @Param("toDate") LocalDateTime toDate);
+
+        @Query("""
+                        SELECT SUM(t.amount)
+                        FROM Transaction t
+                        WHERE t.userId = :userId
+                        AND t.category = :categoryId
+                        AND MONTH(t.createdAt) = :month
+                        AND YEAR(t.createdAt) = :year
+                        """)
+        BigDecimal sumSpendingByCategoryAndMonth(
+                        UUID userId,
+                        int categoryId,
+                        int month,
+                        int year);
 }

--- a/financial_management/src/main/java/com/example/financial_management/services/ReportService.java
+++ b/financial_management/src/main/java/com/example/financial_management/services/ReportService.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.example.financial_management.model.report.response.CategoryDistribution;
 import com.itextpdf.text.*;
 import com.itextpdf.text.pdf.*;
 
@@ -44,6 +45,7 @@ import com.example.financial_management.model.report.response.CategoryReportResp
 import com.example.financial_management.model.report.response.CompareReportResponse;
 import com.example.financial_management.model.report.response.DailyReportResponse;
 import com.example.financial_management.model.report.response.DailyReportResponseItem;
+import com.example.financial_management.model.report.response.DistributionSummary;
 import com.example.financial_management.model.report.response.MonthlyReportResponse;
 import com.example.financial_management.model.report.response.MonthlyReportResponseItem;
 import com.example.financial_management.model.report.response.SummaryReportResponse;
@@ -325,7 +327,7 @@ public class ReportService {
                                 TransactionType.EXPENSE).orElse(BigDecimal.ZERO);
 
                 BigDecimal remaining = totalIncome.subtract(totalExpense);
-                BigDecimal startBalance = endBalance.add(remaining);
+                BigDecimal startBalance = endBalance.subtract(remaining);
 
                 // Lấy lịch sử giao dịch
                 List<TransactionResponse> balanceHistory = transactionRepository.findAllByAccountIdAndUserId(
@@ -340,6 +342,46 @@ public class ReportService {
                 summary.setTotalIncome(totalIncome);
                 summary.setTotalExpense(totalExpense);
                 summary.setBalanceHistory(balanceHistory);
+
+                return summary;
+        }
+
+        public DistributionSummary getReportDistributionByAccount(UUID accountId, Auth auth) {
+                User user = getUser(auth);
+                validateAccountAccess(auth, accountId);
+
+                // Lấy thông tin account
+                Account account = accountRepository.findByIdAndUserId(accountId, user.getId())
+                                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                                                "Account not found"));
+
+                // Tính toán số dư đầu kỳ và cuối kỳ
+                BigDecimal endBalance = account.getBalance(); // Giả sử đây là số dư cuối kỳ
+
+                // Tính tổng thu nhập và chi phí
+                BigDecimal totalIncome = transactionRepository.sumAmountByType(user.getId(), accountId,
+                                TransactionType.INCOME).orElse(BigDecimal.ZERO);
+                BigDecimal totalExpense = transactionRepository.sumAmountByType(user.getId(), accountId,
+                                TransactionType.EXPENSE).orElse(BigDecimal.ZERO);
+
+                BigDecimal remaining = totalIncome.subtract(totalExpense);
+                BigDecimal startBalance = endBalance.subtract(remaining);
+
+                // Lấy lịch sử giao dịch
+                List<CategoryDistribution> incomeByCategory = transactionRepository.sumAmountByCategoryAndType(
+                                user.getId(), accountId, TransactionType.INCOME);
+
+                List<CategoryDistribution> expenseByCategory = transactionRepository.sumAmountByCategoryAndType(
+                                user.getId(), accountId, TransactionType.EXPENSE);
+
+                // Tạo response
+                DistributionSummary summary = new DistributionSummary();
+                summary.setStartBalance(startBalance);
+                summary.setEndBalance(endBalance);
+                summary.setTotalIncome(totalIncome);
+                summary.setTotalExpense(totalExpense);
+                summary.setIncomeByCategory(incomeByCategory);
+                summary.setExpenseByCategory(expenseByCategory);
 
                 return summary;
         }


### PR DESCRIPTION
The report for distribution by account previously listed all individual income and expense transactions. This has been updated to sum the income and expenses for each category, providing a more concise summary. • Added sumAmountByCategoryAndType to TransactionRepository to aggregate transaction amounts at the database level. • Created a new CategoryDistribution response model to hold the aggregated data. • Updated DistributionSummary to use a list of CategoryDistribution objects instead of TransactionResponse. • Modified ReportService.getReportDistributionByAccount to use the new repository method and return the aggregated data.